### PR TITLE
Add download page

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -9,7 +9,7 @@ const GitHub = require('github-api')
 const uuid = require('uuid').v4
 const marked = require('marked')
 
-module.exports = function(api) {
+module.exports = function (api) {
 	api.loadSource(
 		async ({
 			addCollection,
@@ -38,6 +38,15 @@ module.exports = function(api) {
 					!filteredContributors.find(({ login }) => d.login === login)
 				)
 					filteredContributors.push(d)
+			})
+
+			// Release data
+			const releases = addCollection({
+				typeName: 'Release'
+			})
+			const releaseData = (await bridgeRepo.listReleases()).data
+			releaseData.forEach(release => {
+				releases.addNode(release)
 			})
 
 			const contributors = addCollection({

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -9,7 +9,7 @@ const GitHub = require('github-api')
 const uuid = require('uuid').v4
 const marked = require('marked')
 
-module.exports = function (api) {
+module.exports = function(api) {
 	api.loadSource(
 		async ({
 			addCollection,
@@ -42,10 +42,11 @@ module.exports = function (api) {
 
 			// Release data
 			const releases = addCollection({
-				typeName: 'Release'
+				typeName: 'Release',
 			})
 			const releaseData = (await bridgeRepo.listReleases()).data
 			releaseData.forEach(release => {
+				if (release.body) release.content = marked(release.body)
 				releases.addNode(release)
 			})
 

--- a/src/pages/Download.vue
+++ b/src/pages/Download.vue
@@ -1,8 +1,21 @@
 <template>
 	<Layout :showSidebars="false">
 		<div class="mt-12 mx-12">
-			<h1>Download</h1>
-			<div>{{ latestRelease }}</div>
+			<h1>Download {{ latestRelease.name }}</h1>
+
+			<div v-html="latestRelease.content"></div>
+
+			<div v-if="downloadForOs" class="flex mt-8 flex-wrap -mx-4">
+				<g-link
+					:to="downloadForOs"
+					class="flex items-center px-6 py-4 text-2xl font-bold leading-none text-white border rounded-lg shadow-lg bg-ui-primary border-ui-primary transition-all duration-200 ease-out transform hover:shadow-xl hover:-translate-y-1 mb-4 mx-2"
+				>
+					Download
+					<DownloadCloudIcon class="ml-4" size="1x" />
+				</g-link>
+			</div>
+
+			<p v-else>bridge. is not available for your platform.</p>
 		</div>
 	</Layout>
 </template>
@@ -17,6 +30,7 @@ query {
 				tag_name
 				draft
 				prerelease
+				content
 				assets {
 					name
 					browser_download_url
@@ -30,7 +44,12 @@ query {
 </static-query>
 
 <script>
+import { DownloadCloudIcon } from 'vue-feather-icons'
+
 export default {
+	components: {
+		DownloadCloudIcon,
+	},
 	computed: {
 		latestRelease() {
 			for (let release of this.$static.allRelease.edges) {
@@ -38,7 +57,7 @@ export default {
 				if (release.node.draft || release.node.prerelease) continue
 
 				let winAsset, linuxAsset, macAsset
-				release.node.assets.forEach((asset) => {
+				release.node.assets.forEach(asset => {
 					if (asset.state !== 'uploaded') return
 
 					// Determine file extension
@@ -65,9 +84,25 @@ export default {
 					winAsset,
 					linuxAsset,
 					macAsset,
+					content: release.node.content,
 				}
 			}
+		},
+		downloadForOs() {
+			if (navigator.platform.includes('Win'))
+				return this.latestRelease.winAsset.browser_download_url
+			else if (navigator.platform.includes('Mac'))
+				return this.latestRelease.macAsset.browser_download_url
+			else if (navigator.platform.includes('Linux'))
+				return this.latestRelease.linuxAsset.browser_download_url
 		},
 	},
 }
 </script>
+
+<style>
+ul {
+	list-style: unset;
+	padding-left: 2rem;
+}
+</style>

--- a/src/pages/Download.vue
+++ b/src/pages/Download.vue
@@ -1,0 +1,73 @@
+<template>
+	<Layout :showSidebars="false">
+		<div class="mt-12 mx-12">
+			<h1>Download</h1>
+			<div>{{ latestRelease }}</div>
+		</div>
+	</Layout>
+</template>
+
+<static-query>
+query {
+	allRelease(sortBy: "id", order: DESC) {
+		edges {
+			node {
+				name
+				html_url
+				tag_name
+				draft
+				prerelease
+				assets {
+					name
+					browser_download_url
+					state
+					size
+				}
+			}
+		}
+	}
+}
+</static-query>
+
+<script>
+export default {
+	computed: {
+		latestRelease() {
+			for (let release of this.$static.allRelease.edges) {
+				// Check release isn't a draft or prerelease
+				if (release.node.draft || release.node.prerelease) continue
+
+				let winAsset, linuxAsset, macAsset
+				release.node.assets.forEach((asset) => {
+					if (asset.state !== 'uploaded') return
+
+					// Determine file extension
+					let parts = asset.name.split('.')
+					let ext = parts[parts.length - 1]
+
+					if (ext === 'exe') winAsset = asset
+					else if (ext === 'AppImage') linuxAsset = asset
+					else if (ext === 'dmg') macAsset = asset
+				})
+
+				// Check the assets for this release are uploaded, otherwise skip this release
+				if (
+					winAsset === undefined ||
+					linuxAsset === undefined ||
+					macAsset === undefined
+				)
+					continue
+
+				// Return the valid release
+				return {
+					name: release.node.name,
+					url: release.node.html_url,
+					winAsset,
+					linuxAsset,
+					macAsset,
+				}
+			}
+		},
+	},
+}
+</script>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -28,8 +28,8 @@
 
 				<div class="flex justify-center mt-8 flex-wrap -mx-4">
 					<g-link
-						to="https://github.com/bridge-core/bridge./releases/latest"
-						class="flex items-center px-6 py-4  text-2xl font-bold leading-none text-white border rounded-lg shadow-lg bg-ui-primary border-ui-primary transition-all duration-200 ease-out transform hover:shadow-xl hover:-translate-y-1 mb-4 mx-2"
+						to="/download/"
+						class="flex items-center px-6 py-4 text-2xl font-bold leading-none text-white border rounded-lg shadow-lg bg-ui-primary border-ui-primary transition-all duration-200 ease-out transform hover:shadow-xl hover:-translate-y-1 mb-4 mx-2"
 					>
 						Download
 						<DownloadCloudIcon class="ml-4" size="1x" />
@@ -135,9 +135,7 @@
 
 			<div class="text-center">
 				<h1>Getting Inspired</h1>
-				<p>
-					bridge. has been used to create various awesome projects.
-				</p>
+				<p>bridge. has been used to create various awesome projects.</p>
 				<div class="flex justify-center mt-8 flex-wrap -mx-4">
 					<g-link
 						to="/creations/"


### PR DESCRIPTION
# Description

As the title suggests, this PR is intended to monitor progress on the custom download page for bridge.

# Key Features

This download page will allow users to easily download the executable for their platform without having to look through the GitHub release assets.