### PR TITLE
Fixing mini header consistency.

### DIFF
--- a/content/docs/plugin-docs/modules/fetch-definition.md
+++ b/content/docs/plugin-docs/modules/fetch-definition.md
@@ -5,7 +5,7 @@ sidebar: 'plugins'
 
 # @bridge/fetch-definition
 
-Grants access to the lightning cache database
+Grants access to the lightning cache database.
 
 ## Fetching lightning cache data
 


### PR DESCRIPTION
Every other top mini header has proper punctuation, fixing consistency.